### PR TITLE
[#37] Remove maven.test.failure.ignore property from pom.xml. This is…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,8 +223,6 @@
             <id>all</id>
             <properties>
                 <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
-                <!-- this prevents to skip execution of "domain" tests if any of "standalone" tests fails -->
-                <maven.test.failure.ignore>true</maven.test.failure.ignore>
             </properties>
             <build>
                 <plugins>


### PR DESCRIPTION
… for Travis CI to fail fast when any of the tests fail. Otherwise Travis CI marks build as successful.